### PR TITLE
Fix toggle in expanded TOC items and undefined slider on pages without tables

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -137,28 +137,28 @@
                 <div class="toc">
                     <ol>
                         <!-- <li>
-                            <a rel="noopener noreferrer" target="_self" href="#9-1-2023" onclick="toggleFunction()" class="toc_h_one">Sept 1, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#9-1-2023" onclick="smToggleFunction()" class="toc_h_one">Sept 1, 2023</a>
                         </li> -->
                         <!-- <li>
-                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="toggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
+                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="smToggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
                         </li> -->
                         <!-- <li>
-                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="toggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
+                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="smToggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
                         </li> -->
                         <!-- <li>
-                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="toggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
+                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="smToggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
                         </li> -->
                         <!-- <li>
-                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="toggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
+                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="smToggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
                         </li> -->
                         <!-- <li>
-                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="toggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
+                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="smToggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
                         </li> -->
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#1-21-2024" onclick="toggleFunction()" class="toc_h_one">Jan 21st, 2024</a>
+                            <a rel="noopener noreferrer" target="_self" href="#1-21-2024" onclick="smToggleFunction()" class="toc_h_one">Jan 21st, 2024</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="toggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
+                            <a rel="noopener noreferrer" target="_self" href="#1-5-2024" onclick="smToggleFunction()" class="toc_h_one">Jan 5th, 2024</a>
                         </li>
                     <ol>
                 </div>

--- a/changelog2023.html
+++ b/changelog2023.html
@@ -137,58 +137,58 @@
                 <div class="toc">
                     <ol>
                         <!-- <li>
-                            <a rel="noopener noreferrer" target="_self" href="#9-1-2023" onclick="toggleFunction()" class="toc_h_one">Sept 1, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#9-1-2023" onclick="smToggleFunction()" class="toc_h_one">Sept 1, 2023</a>
                         </li> -->
                         <!-- <li>
-                            <a rel="noopener noreferrer" target="_self" href="#9-1-2023" onclick="toggleFunction()" class="toc_h_one">Sept 1, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#9-1-2023" onclick="smToggleFunction()" class="toc_h_one">Sept 1, 2023</a>
                         </li> -->
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#12-27-2023" onclick="toggleFunction()" class="toc_h_one">Dec 27, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#12-27-2023" onclick="smToggleFunction()" class="toc_h_one">Dec 27, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#11-24-2023" onclick="toggleFunction()" class="toc_h_one">Nov 24, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#11-24-2023" onclick="smToggleFunction()" class="toc_h_one">Nov 24, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#10-30-2023" onclick="toggleFunction()" class="toc_h_one">Oct 30, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#10-30-2023" onclick="smToggleFunction()" class="toc_h_one">Oct 30, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#10-15-2023" onclick="toggleFunction()" class="toc_h_one">Oct 15, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#10-15-2023" onclick="smToggleFunction()" class="toc_h_one">Oct 15, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#10-01-2023" onclick="toggleFunction()" class="toc_h_one">Oct 1, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#10-01-2023" onclick="smToggleFunction()" class="toc_h_one">Oct 1, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#9-15-2023" onclick="toggleFunction()" class="toc_h_one">Sept 15, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#9-15-2023" onclick="smToggleFunction()" class="toc_h_one">Sept 15, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#9-11-2023" onclick="toggleFunction()" class="toc_h_one">Sept 11, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#9-11-2023" onclick="smToggleFunction()" class="toc_h_one">Sept 11, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#9-10-2023" onclick="toggleFunction()" class="toc_h_one">Sept 10, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#9-10-2023" onclick="smToggleFunction()" class="toc_h_one">Sept 10, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#9-7-2023" onclick="toggleFunction()" class="toc_h_one">Sept 7, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#9-7-2023" onclick="smToggleFunction()" class="toc_h_one">Sept 7, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#9-1-2023" onclick="toggleFunction()" class="toc_h_one">Sept 1, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#9-1-2023" onclick="smToggleFunction()" class="toc_h_one">Sept 1, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#8-29-2023" onclick="toggleFunction()" class="toc_h_one">Aug 29, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#8-29-2023" onclick="smToggleFunction()" class="toc_h_one">Aug 29, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#8-20-2023" onclick="toggleFunction()" class="toc_h_one">Aug 20, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#8-20-2023" onclick="smToggleFunction()" class="toc_h_one">Aug 20, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#8-16-2023" onclick="toggleFunction()" class="toc_h_one">Aug 16, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#8-16-2023" onclick="smToggleFunction()" class="toc_h_one">Aug 16, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#7-30-2023" onclick="toggleFunction()" class="toc_h_one">Jul 30, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#7-30-2023" onclick="smToggleFunction()" class="toc_h_one">Jul 30, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#7-24-2023" onclick="toggleFunction()" class="toc_h_one">Jul 24, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#7-24-2023" onclick="smToggleFunction()" class="toc_h_one">Jul 24, 2023</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#7-19-2023" onclick="toggleFunction()" class="toc_h_one">Jul 19, 2023</a>
+                            <a rel="noopener noreferrer" target="_self" href="#7-19-2023" onclick="smToggleFunction()" class="toc_h_one">Jul 19, 2023</a>
                         </li>
                     <ol>
                 </div>

--- a/common_resource.html
+++ b/common_resource.html
@@ -135,50 +135,50 @@
                 <div class="toc">
                     <ol>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#notes" onclick="toggleFunction()" class="toc_h_one">Notes</a>
+                            <a rel="noopener noreferrer" target="_self" href="#notes" onclick="smToggleFunction()" class="toc_h_one">Notes</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#terminology" onclick="toggleFunction()" class="toc_h_two">Terminology</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#terminology" onclick="smToggleFunction()" class="toc_h_two">Terminology</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#glossary" onclick="toggleFunction()" class="toc_h_two">Glossary</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#glossary" onclick="smToggleFunction()" class="toc_h_two">Glossary</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#renewable" onclick="toggleFunction()" class="toc_h_one">Renewable Resources</a>
+                            <a rel="noopener noreferrer" target="_self" href="#renewable" onclick="smToggleFunction()" class="toc_h_one">Renewable Resources</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#currency" onclick="toggleFunction()" class="toc_h_two">Currency</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#currency" onclick="smToggleFunction()" class="toc_h_two">Currency</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#consumables" onclick="toggleFunction()" class="toc_h_two">Consumables</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#consumables" onclick="smToggleFunction()" class="toc_h_two">Consumables</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#coggies" onclick="toggleFunction()" class="toc_h_two">Cognitive Awakening</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#coggies" onclick="smToggleFunction()" class="toc_h_two">Cognitive Awakening</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#bulins" onclick="toggleFunction()" class="toc_h_two">Bulins</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#bulins" onclick="smToggleFunction()" class="toc_h_two">Bulins</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#gear_enhance" onclick="toggleFunction()" class="toc_h_two">Gear Upgrade Parts</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#gear_enhance" onclick="smToggleFunction()" class="toc_h_two">Gear Upgrade Parts</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#augmentation" onclick="toggleFunction()" class="toc_h_two">Augmentation Materials</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#augmentation" onclick="smToggleFunction()" class="toc_h_two">Augmentation Materials</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#skill_books" onclick="toggleFunction()" class="toc_h_two">Skill Books</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#skill_books" onclick="smToggleFunction()" class="toc_h_two">Skill Books</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#retrofit_bps" onclick="toggleFunction()" class="toc_h_two">Retrofit Blueprints</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#retrofit_bps" onclick="smToggleFunction()" class="toc_h_two">Retrofit Blueprints</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#finite" onclick="toggleFunction()" class="toc_h_one">(Almost) Finite Resources</a>
+                            <a rel="noopener noreferrer" target="_self" href="#finite" onclick="smToggleFunction()" class="toc_h_one">(Almost) Finite Resources</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#finite-currency" onclick="toggleFunction()" class="toc_h_two">Currency</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#finite-currency" onclick="smToggleFunction()" class="toc_h_two">Currency</a>
                                 </li>
                             </ol>
                         </li>

--- a/custom_js/guide_page.js
+++ b/custom_js/guide_page.js
@@ -4,28 +4,29 @@ const slider = document.querySelector('.table-responsive');
 let mouseDown = false;
 let startX, scrollLeft;
 
-let startDragging = function (e) {
-  mouseDown = true;
-  startX = e.pageX - slider.offsetLeft;
-  scrollLeft = slider.scrollLeft;
-};
-let stopDragging = function (event) {
-  mouseDown = false;
-};
+if (slider) {
+  let startDragging = function (e) {
+    mouseDown = true;
+    startX = e.pageX - slider.offsetLeft;
+    scrollLeft = slider.scrollLeft;
+  };
+  let stopDragging = function (e) {
+    mouseDown = false;
+  };
 
-slider.addEventListener('mousemove', (e) => {
-  e.preventDefault();
-  if(!mouseDown) { return; }
-  const x = e.pageX - slider.offsetLeft;
-  const scroll = x - startX;
-  slider.scrollLeft = scrollLeft - scroll;
-});
+  slider.addEventListener('mousemove', (e) => {
+    e.preventDefault();
+    if(!mouseDown) { return; }
+    const x = e.pageX - slider.offsetLeft;
+    const scroll = x - startX;
+    slider.scrollLeft = scrollLeft - scroll;
+  });
 
-// Event listeners
-slider.addEventListener('mousedown', startDragging, false);
-slider.addEventListener('mouseup', stopDragging, false);
-slider.addEventListener('mouseleave', stopDragging, false);
-
+  // Event listeners
+  slider.addEventListener('mousedown', startDragging, false);
+  slider.addEventListener('mouseup', stopDragging, false);
+  slider.addEventListener('mouseleave', stopDragging, false);
+}
 
 //SideNav
 function toggleFunction() {
@@ -53,6 +54,12 @@ function toggleFunction() {
       sidenavButton.classList.remove("custom-sidenav-collapse");
       main.classList.remove("custom-sidenav-collapse");
     }
+  }
+}
+
+function smToggleFunction() {
+  if (window.innerWidth < 1000) {
+    toggleFunction();
   }
 }
 

--- a/early_ship_recommendations.html
+++ b/early_ship_recommendations.html
@@ -135,22 +135,22 @@
                 <div class="toc">
                     <ol>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#starter" onclick="toggleFunction()" class="toc_h_one">Starter Ships</a>
+                            <a rel="noopener noreferrer" target="_self" href="#starter" onclick="smToggleFunction()" class="toc_h_one">Starter Ships</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#guild_shop" onclick="toggleFunction()" class="toc_h_one">Guild Shop</a>
+                            <a rel="noopener noreferrer" target="_self" href="#guild_shop" onclick="smToggleFunction()" class="toc_h_one">Guild Shop</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#medal_shop" onclick="toggleFunction()" class="toc_h_one">Medal Shop</a>
+                            <a rel="noopener noreferrer" target="_self" href="#medal_shop" onclick="smToggleFunction()" class="toc_h_one">Medal Shop</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#core_data_shop" onclick="toggleFunction()" class="toc_h_one">Core Data Shop</a>
+                            <a rel="noopener noreferrer" target="_self" href="#core_data_shop" onclick="smToggleFunction()" class="toc_h_one">Core Data Shop</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#map_drops" onclick="toggleFunction()" class="toc_h_one">Map Drops</a>
+                            <a rel="noopener noreferrer" target="_self" href="#map_drops" onclick="smToggleFunction()" class="toc_h_one">Map Drops</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#research" onclick="toggleFunction()" class="toc_h_one">Research (PR/DR) Ships</a>
+                            <a rel="noopener noreferrer" target="_self" href="#research" onclick="smToggleFunction()" class="toc_h_one">Research (PR/DR) Ships</a>
                         </li>
                     <ol>
                 </div>

--- a/farming.html
+++ b/farming.html
@@ -135,84 +135,84 @@
                 <div class="toc">
                     <ol>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#terminology" onclick="toggleFunction()" class="toc_h_one">Terminology</a>
+                            <a rel="noopener noreferrer" target="_self" href="#terminology" onclick="smToggleFunction()" class="toc_h_one">Terminology</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#fleetbuilding_for_farming" onclick="toggleFunction()" class="toc_h_one">Fleetbuilding For Farming</a>
+                            <a rel="noopener noreferrer" target="_self" href="#fleetbuilding_for_farming" onclick="smToggleFunction()" class="toc_h_one">Fleetbuilding For Farming</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#initial_considerations" onclick="toggleFunction()" class="toc_h_two">Initial Considerations</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#initial_considerations" onclick="smToggleFunction()" class="toc_h_two">Initial Considerations</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#helpful_ship_qualities" onclick="toggleFunction()" class="toc_h_two">Helpful Ship Qualities</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#helpful_ship_qualities" onclick="smToggleFunction()" class="toc_h_two">Helpful Ship Qualities</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#farming_methods" onclick="toggleFunction()" class="toc_h_one">Farming Methods</a>
+                            <a rel="noopener noreferrer" target="_self" href="#farming_methods" onclick="smToggleFunction()" class="toc_h_one">Farming Methods</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#farming_campaign" onclick="toggleFunction()" class="toc_h_one">Farming Campaign</a>
+                            <a rel="noopener noreferrer" target="_self" href="#farming_campaign" onclick="smToggleFunction()" class="toc_h_one">Farming Campaign</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#for_gear_campaign" onclick="toggleFunction()" class="toc_h_two">For Gear</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#for_gear_campaign" onclick="smToggleFunction()" class="toc_h_two">For Gear</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#for_exp_campaign" onclick="toggleFunction()" class="toc_h_two">For Ship EXP, PR Grinding, Commander Level EXP, Coins, and Upgrade Parts</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#for_exp_campaign" onclick="smToggleFunction()" class="toc_h_two">For Ship EXP, PR Grinding, Commander Level EXP, Coins, and Upgrade Parts</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#for_coggies" onclick="toggleFunction()" class="toc_h_two">For Cognitive Chips and Augment Module Stones</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#for_coggies" onclick="smToggleFunction()" class="toc_h_two">For Cognitive Chips and Augment Module Stones</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#for_retrofit_bps" onclick="toggleFunction()" class="toc_h_two">For Retrofit Blueprints</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#for_retrofit_bps" onclick="smToggleFunction()" class="toc_h_two">For Retrofit Blueprints</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#for_drop_ships_campaign" onclick="toggleFunction()" class="toc_h_two">For Drop Ships</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#for_drop_ships_campaign" onclick="smToggleFunction()" class="toc_h_two">For Drop Ships</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#war_archives" onclick="toggleFunction()" class="toc_h_one">Farming War Archives</a>
+                            <a rel="noopener noreferrer" target="_self" href="#war_archives" onclick="smToggleFunction()" class="toc_h_one">Farming War Archives</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#for_gear_wa" onclick="toggleFunction()" class="toc_h_two">For Gear</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#for_gear_wa" onclick="smToggleFunction()" class="toc_h_two">For Gear</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#for_drop_ships_wa" onclick="toggleFunction()" class="toc_h_two">For Drop Ships</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#for_drop_ships_wa" onclick="smToggleFunction()" class="toc_h_two">For Drop Ships</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#events" onclick="toggleFunction()" class="toc_h_one">Farming Events</a>
+                            <a rel="noopener noreferrer" target="_self" href="#events" onclick="smToggleFunction()" class="toc_h_one">Farming Events</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#for_event_currency" onclick="toggleFunction()" class="toc_h_two">For Event Currency</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#for_event_currency" onclick="smToggleFunction()" class="toc_h_two">For Event Currency</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#event_shop_priority" onclick="toggleFunction()" class="toc_h_two">Event Shop Priority</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#event_shop_priority" onclick="smToggleFunction()" class="toc_h_two">Event Shop Priority</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#for_drop_ships_and_gear" onclick="toggleFunction()" class="toc_h_two">For Drop Ships and Gear</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#for_drop_ships_and_gear" onclick="smToggleFunction()" class="toc_h_two">For Drop Ships and Gear</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#farming_opsi" onclick="toggleFunction()" class="toc_h_one">Farming Operation Siren</a>
+                            <a rel="noopener noreferrer" target="_self" href="#farming_opsi" onclick="smToggleFunction()" class="toc_h_one">Farming Operation Siren</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#opsi_fleetbuilding" onclick="toggleFunction()" class="toc_h_two">Operation Siren Fleetbuilding</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#opsi_fleetbuilding" onclick="smToggleFunction()" class="toc_h_two">Operation Siren Fleetbuilding</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#bare_minimum" onclick="toggleFunction()" class="toc_h_two">The Bare Minimum</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#bare_minimum" onclick="smToggleFunction()" class="toc_h_two">The Bare Minimum</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#opsi_shops" onclick="toggleFunction()" class="toc_h_two">Shops</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#opsi_shops" onclick="smToggleFunction()" class="toc_h_two">Shops</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#opsi_star_farming" onclick="toggleFunction()" class="toc_h_two">Star Farming</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#opsi_star_farming" onclick="smToggleFunction()" class="toc_h_two">Star Farming</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#opsi_ap_drain" onclick="toggleFunction()" class="toc_h_two">Excess AP Draining (Cat Node Farming)</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#opsi_ap_drain" onclick="smToggleFunction()" class="toc_h_two">Excess AP Draining (Cat Node Farming)</a>
                                 </li>
                             </ol>
                         </li>

--- a/fleet_technology.html
+++ b/fleet_technology.html
@@ -150,22 +150,22 @@
                 <div class="toc">
                     <ol>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#acquisition" onclick="toggleFunction()" class="h_two">Tech Point Acquisition</a>
+                            <a rel="noopener noreferrer" target="_self" href="#acquisition" onclick="smToggleFunction()" class="h_two">Tech Point Acquisition</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#kms" onclick="toggleFunction()" class="h_three">Iron Blood</a>
+                            <a rel="noopener noreferrer" target="_self" href="#kms" onclick="smToggleFunction()" class="h_three">Iron Blood</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#de" onclick="toggleFunction()" class="h_three">Dragon Empery</a>
+                            <a rel="noopener noreferrer" target="_self" href="#de" onclick="smToggleFunction()" class="h_three">Dragon Empery</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#rn" onclick="toggleFunction()" class="h_three">Sardegna Empire</a>
+                            <a rel="noopener noreferrer" target="_self" href="#rn" onclick="smToggleFunction()" class="h_three">Sardegna Empire</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#ffnf" onclick="toggleFunction()" class="h_three">Iris Libre</a>
+                            <a rel="noopener noreferrer" target="_self" href="#ffnf" onclick="smToggleFunction()" class="h_three">Iris Libre</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#mnf" onclick="toggleFunction()" class="h_three">Vichya Dominion</a>
+                            <a rel="noopener noreferrer" target="_self" href="#mnf" onclick="smToggleFunction()" class="h_three">Vichya Dominion</a>
                         </li>
                     </ol>
                 </div>

--- a/fleetbuilding.html
+++ b/fleetbuilding.html
@@ -134,143 +134,143 @@
                 <div class="toc">
                     <ol>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#just_started" onclick="toggleFunction()" class="toc_h_one">If you just started Azur Lane...</a>
+                            <a rel="noopener noreferrer" target="_self" href="#just_started" onclick="smToggleFunction()" class="toc_h_one">If you just started Azur Lane...</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#mob_vs_boss" onclick="toggleFunction()" class="toc_h_one">Mob Fleet vs Boss Fleet</a>
+                            <a rel="noopener noreferrer" target="_self" href="#mob_vs_boss" onclick="smToggleFunction()" class="toc_h_one">Mob Fleet vs Boss Fleet</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#backline" onclick="toggleFunction()" class="toc_h_one">Backline Ship Roles</a>
+                            <a rel="noopener noreferrer" target="_self" href="#backline" onclick="smToggleFunction()" class="toc_h_one">Backline Ship Roles</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#healer" onclick="toggleFunction()" class="toc_h_two">Healer</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#healer" onclick="smToggleFunction()" class="toc_h_two">Healer</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#flagship_bb" onclick="toggleFunction()" class="toc_h_two">Flagship BB</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#flagship_bb" onclick="smToggleFunction()" class="toc_h_two">Flagship BB</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#off-flag_bb" onclick="toggleFunction()" class="toc_h_two">Off-Flag BB</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#off-flag_bb" onclick="smToggleFunction()" class="toc_h_two">Off-Flag BB</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#damage_cv" onclick="toggleFunction()" class="toc_h_two">Damage CV</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#damage_cv" onclick="smToggleFunction()" class="toc_h_two">Damage CV</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#backline_support" onclick="toggleFunction()" class="toc_h_two">Support</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#backline_support" onclick="smToggleFunction()" class="toc_h_two">Support</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#vg" onclick="toggleFunction()" class="toc_h_one">Vanguard Ship Roles</a>
+                            <a rel="noopener noreferrer" target="_self" href="#vg" onclick="smToggleFunction()" class="toc_h_one">Vanguard Ship Roles</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#mob_main_tank" onclick="toggleFunction()" class="toc_h_two">Mob Main Tank</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#mob_main_tank" onclick="smToggleFunction()" class="toc_h_two">Mob Main Tank</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#boss_main_tank" onclick="toggleFunction()" class="toc_h_two">Boss Main Tank</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#boss_main_tank" onclick="smToggleFunction()" class="toc_h_two">Boss Main Tank</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#vg_damage_dealer" onclick="toggleFunction()" class="toc_h_two">Damage Dealer</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#vg_damage_dealer" onclick="smToggleFunction()" class="toc_h_two">Damage Dealer</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#vg_support" onclick="toggleFunction()" class="toc_h_two">Support</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#vg_support" onclick="smToggleFunction()" class="toc_h_two">Support</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#damage_stagger" onclick="toggleFunction()" class="toc_h_one">Fast Loads / Staggering Damage</a>
+                            <a rel="noopener noreferrer" target="_self" href="#damage_stagger" onclick="smToggleFunction()" class="toc_h_one">Fast Loads / Staggering Damage</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#fast_loader_list" onclick="toggleFunction()" class="toc_h_two">List of Fast Loader Ships</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#fast_loader_list" onclick="smToggleFunction()" class="toc_h_two">List of Fast Loader Ships</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#skill_sync" onclick="toggleFunction()" class="toc_h_one">Skill Syncing</a>
+                            <a rel="noopener noreferrer" target="_self" href="#skill_sync" onclick="smToggleFunction()" class="toc_h_one">Skill Syncing</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#timed_skill" onclick="toggleFunction()" class="toc_h_two">Timed Skill Syncing</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#timed_skill" onclick="smToggleFunction()" class="toc_h_two">Timed Skill Syncing</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#on_shot_sync" onclick="toggleFunction()" class="toc_h_two">On Shot / Strike Syncing</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#on_shot_sync" onclick="smToggleFunction()" class="toc_h_two">On Shot / Strike Syncing</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#faction_fleets" onclick="toggleFunction()" class="toc_h_two">Faction Fleets</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#faction_fleets" onclick="smToggleFunction()" class="toc_h_two">Faction Fleets</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#pair_skills" onclick="toggleFunction()" class="toc_h_two">Pair Skills</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#pair_skills" onclick="smToggleFunction()" class="toc_h_two">Pair Skills</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#damage_distribution" onclick="toggleFunction()" class="toc_h_one">Damage Distribution</a>
+                            <a rel="noopener noreferrer" target="_self" href="#damage_distribution" onclick="smToggleFunction()" class="toc_h_one">Damage Distribution</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#backline_dmg_dist" onclick="toggleFunction()" class="toc_h_two">Backline</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#backline_dmg_dist" onclick="smToggleFunction()" class="toc_h_two">Backline</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#vanguard_dmg_dist" onclick="toggleFunction()" class="toc_h_two">Vanguard</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#vanguard_dmg_dist" onclick="smToggleFunction()" class="toc_h_two">Vanguard</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#campaign_fleet_comps" onclick="toggleFunction()" class="toc_h_one">Campaign Fleet Compositions</a>
+                            <a rel="noopener noreferrer" target="_self" href="#campaign_fleet_comps" onclick="smToggleFunction()" class="toc_h_one">Campaign Fleet Compositions</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#campaign_theory" onclick="toggleFunction()" class="toc_h_two">Theory</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#campaign_theory" onclick="smToggleFunction()" class="toc_h_two">Theory</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#mob_fleet" onclick="toggleFunction()" class="toc_h_two">Mob Fleet</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#mob_fleet" onclick="smToggleFunction()" class="toc_h_two">Mob Fleet</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#generic_boss_fleet" onclick="toggleFunction()" class="toc_h_two">Boss Fleet</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#generic_boss_fleet" onclick="smToggleFunction()" class="toc_h_two">Boss Fleet</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#opsi_fleet_comps" onclick="toggleFunction()" class="toc_h_one">Operation Siren Fleet Compositions</a>
+                            <a rel="noopener noreferrer" target="_self" href="#opsi_fleet_comps" onclick="smToggleFunction()" class="toc_h_one">Operation Siren Fleet Compositions</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#opsi_theory" onclick="toggleFunction()" class="toc_h_two">Theory</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#opsi_theory" onclick="smToggleFunction()" class="toc_h_two">Theory</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#opsi_mob_fleet" onclick="toggleFunction()" class="toc_h_two">Mob Fleet (Operation Siren)</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#opsi_mob_fleet" onclick="smToggleFunction()" class="toc_h_two">Mob Fleet (Operation Siren)</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#opsi_generic_boss_fleet" onclick="toggleFunction()" class="toc_h_two">Generic Boss Fleet (Operation Siren)</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#opsi_generic_boss_fleet" onclick="smToggleFunction()" class="toc_h_two">Generic Boss Fleet (Operation Siren)</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#opsi_bb_fleet" onclick="toggleFunction()" class="toc_h_two">BB Boss Fleet (Operation Siren)</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#opsi_bb_fleet" onclick="smToggleFunction()" class="toc_h_two">BB Boss Fleet (Operation Siren)</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#opsi_cv_fleet" onclick="toggleFunction()" class="toc_h_two">CV Boss Fleet (Operation Siren)</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#opsi_cv_fleet" onclick="smToggleFunction()" class="toc_h_two">CV Boss Fleet (Operation Siren)</a>
                                     <ol>
                                         <li>
-                                            <a rel="noopener noreferrer" target="_self" href="#ryuusei_cv_fleet" onclick="toggleFunction()" class="toc_h_three">"Ryuusei" Fleet</a>
+                                            <a rel="noopener noreferrer" target="_self" href="#ryuusei_cv_fleet" onclick="smToggleFunction()" class="toc_h_three">"Ryuusei" Fleet</a>
                                         </li>
                                         <li>
-                                            <a rel="noopener noreferrer" target="_self" href="#rocket_cv_fleet" onclick="toggleFunction()" class="toc_h_three">"Rocket" Fleet</a>
+                                            <a rel="noopener noreferrer" target="_self" href="#rocket_cv_fleet" onclick="smToggleFunction()" class="toc_h_three">"Rocket" Fleet</a>
                                         </li>
                                     </ol>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#sub_fleet" onclick="toggleFunction()" class="toc_h_one">Submarine Fleet Compositions</a>
+                            <a rel="noopener noreferrer" target="_self" href="#sub_fleet" onclick="smToggleFunction()" class="toc_h_one">Submarine Fleet Compositions</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#sub_fleet_positioning" onclick="toggleFunction()" class="toc_h_two">Submarine Fleet Positions</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#sub_fleet_positioning" onclick="smToggleFunction()" class="toc_h_two">Submarine Fleet Positions</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#global_subs" onclick="toggleFunction()" class="toc_h_two">International Submarine Fleet</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#global_subs" onclick="smToggleFunction()" class="toc_h_two">International Submarine Fleet</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#kms_subs" onclick="toggleFunction()" class="toc_h_two">KMS "Wolfpack" Submarine Fleet</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#kms_subs" onclick="smToggleFunction()" class="toc_h_two">KMS "Wolfpack" Submarine Fleet</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#uss_subs" onclick="toggleFunction()" class="toc_h_two">USS "Fishpack" Submarine Fleet</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#uss_subs" onclick="smToggleFunction()" class="toc_h_two">USS "Fishpack" Submarine Fleet</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#mot_subs" onclick="toggleFunction()" class="toc_h_two">MOT Submarine Fleet</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#mot_subs" onclick="smToggleFunction()" class="toc_h_two">MOT Submarine Fleet</a>
                                 </li>
                                 
                             </ol>

--- a/newbie_tips.html
+++ b/newbie_tips.html
@@ -135,73 +135,73 @@
                 <div class="toc">
                     <ol>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#avoid_yt_guides" onclick="toggleFunction()" class="toc_h_one">Avoid YouTube Guides</a>
+                            <a rel="noopener noreferrer" target="_self" href="#avoid_yt_guides" onclick="smToggleFunction()" class="toc_h_one">Avoid YouTube Guides</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#mail" onclick="toggleFunction()" class="toc_h_one">Mail is a Bank!</a>
+                            <a rel="noopener noreferrer" target="_self" href="#mail" onclick="smToggleFunction()" class="toc_h_one">Mail is a Bank!</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#guild_shop" onclick="toggleFunction()" class="toc_h_one">Guild Shop</a>
+                            <a rel="noopener noreferrer" target="_self" href="#guild_shop" onclick="smToggleFunction()" class="toc_h_one">Guild Shop</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#push_campaign" onclick="toggleFunction()" class="toc_h_one">Push Campaign</a>
+                            <a rel="noopener noreferrer" target="_self" href="#push_campaign" onclick="smToggleFunction()" class="toc_h_one">Push Campaign</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#3-4" onclick="toggleFunction()" class="toc_h_two">Do not farm 3-4</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#3-4" onclick="smToggleFunction()" class="toc_h_two">Do not farm 3-4</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#permanent_ur" onclick="toggleFunction()" class="toc_h_one">Permanent URs are a TRAP</a>
+                            <a rel="noopener noreferrer" target="_self" href="#permanent_ur" onclick="smToggleFunction()" class="toc_h_one">Permanent URs are a TRAP</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#out_of_ammo" onclick="toggleFunction()" class="toc_h_one">My fleet is out of ammo!!!</a>
+                            <a rel="noopener noreferrer" target="_self" href="#out_of_ammo" onclick="smToggleFunction()" class="toc_h_one">My fleet is out of ammo!!!</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#limit_breaks" onclick="toggleFunction()" class="toc_h_one">Limit Breaks</a>
+                            <a rel="noopener noreferrer" target="_self" href="#limit_breaks" onclick="smToggleFunction()" class="toc_h_one">Limit Breaks</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#gear" onclick="toggleFunction()" class="toc_h_one">Gear</a>
+                            <a rel="noopener noreferrer" target="_self" href="#gear" onclick="smToggleFunction()" class="toc_h_one">Gear</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#avoid_farming_gear" onclick="toggleFunction()" class="toc_h_two">Avoid Farming Gear</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#avoid_farming_gear" onclick="smToggleFunction()" class="toc_h_two">Avoid Farming Gear</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#gear_rarity" onclick="toggleFunction()" class="toc_h_two">Gold Gear =/= Good</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#gear_rarity" onclick="smToggleFunction()" class="toc_h_two">Gold Gear =/= Good</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#situational_gear" onclick="toggleFunction()" class="toc_h_two">Gearing is situational</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#situational_gear" onclick="smToggleFunction()" class="toc_h_two">Gearing is situational</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#upgradable_resources" onclick="toggleFunction()" class="toc_h_one">Upgradable Resources</a>
+                            <a rel="noopener noreferrer" target="_self" href="#upgradable_resources" onclick="smToggleFunction()" class="toc_h_one">Upgradable Resources</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#basic_fleetbuilding" onclick="toggleFunction()" class="toc_h_one">Basic Fleetbuilding</a>
+                            <a rel="noopener noreferrer" target="_self" href="#basic_fleetbuilding" onclick="smToggleFunction()" class="toc_h_one">Basic Fleetbuilding</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#fleet_positionings" onclick="toggleFunction()" class="toc_h_two">Fleet Positionings</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#fleet_positionings" onclick="smToggleFunction()" class="toc_h_two">Fleet Positionings</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#faction_fleets" onclick="toggleFunction()" class="toc_h_two">Faction Fleets SUCK</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#faction_fleets" onclick="smToggleFunction()" class="toc_h_two">Faction Fleets SUCK</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#combat_data_packs" onclick="toggleFunction()" class="toc_h_one">Grind Shipyard EXP MANUALLY</a>
+                            <a rel="noopener noreferrer" target="_self" href="#combat_data_packs" onclick="smToggleFunction()" class="toc_h_one">Grind Shipyard EXP MANUALLY</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#gacha" onclick="toggleFunction()" class="toc_h_one">Gacha</a>
+                            <a rel="noopener noreferrer" target="_self" href="#gacha" onclick="smToggleFunction()" class="toc_h_one">Gacha</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#rerolling" onclick="toggleFunction()" class="toc_h_one">Rerolling</a>
+                            <a rel="noopener noreferrer" target="_self" href="#rerolling" onclick="smToggleFunction()" class="toc_h_one">Rerolling</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#hard_mode_cheese" onclick="toggleFunction()" class="toc_h_one">Hard Mode Cheese</a>
+                            <a rel="noopener noreferrer" target="_self" href="#hard_mode_cheese" onclick="smToggleFunction()" class="toc_h_one">Hard Mode Cheese</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#shops" onclick="toggleFunction()" class="toc_h_one">Shop Priority</a>
+                            <a rel="noopener noreferrer" target="_self" href="#shops" onclick="smToggleFunction()" class="toc_h_one">Shop Priority</a>
                         </li>                    
                     <ol>
                 </div>

--- a/research.html
+++ b/research.html
@@ -150,72 +150,72 @@
                 <div class="toc">
                     <ol>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#fleet_technology" onclick="toggleFunction()" class="h_one">Fleet Technology</a>
+                            <a rel="noopener noreferrer" target="_self" href="#fleet_technology" onclick="smToggleFunction()" class="h_one">Fleet Technology</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#shipyard" onclick="toggleFunction()" class="h_one">Shipyard</a>
+                            <a rel="noopener noreferrer" target="_self" href="#shipyard" onclick="smToggleFunction()" class="h_one">Shipyard</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#coin-up" onclick="toggleFunction()" class="h_two">Coin-up</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#coin-up" onclick="smToggleFunction()" class="h_two">Coin-up</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#shipyard_priority" onclick="toggleFunction()" class="h_two">Recommended Shipyard Priority</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#shipyard_priority" onclick="smToggleFunction()" class="h_two">Recommended Shipyard Priority</a>
                                     <ol>
                                         <li>
-                                            <a rel="noopener noreferrer" target="_self" href="#development_order" onclick="toggleFunction()" class="h_three">Recommended Development Order</a>
+                                            <a rel="noopener noreferrer" target="_self" href="#development_order" onclick="smToggleFunction()" class="h_three">Recommended Development Order</a>
                                         </li>
                                         <li>
-                                            <a rel="noopener noreferrer" target="_self" href="#shipyard_priority_by_season" onclick="toggleFunction()" class="h_three">Shipyard Priority by Season</a>
+                                            <a rel="noopener noreferrer" target="_self" href="#shipyard_priority_by_season" onclick="smToggleFunction()" class="h_three">Shipyard Priority by Season</a>
                                         </li>
                                     </ol>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#research_academy" onclick="toggleFunction()" class="h_one">Research Academy</a>
+                            <a rel="noopener noreferrer" target="_self" href="#research_academy" onclick="smToggleFunction()" class="h_one">Research Academy</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#research_purpose" onclick="toggleFunction()" class="h_two">Purpose of Research</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#research_purpose" onclick="smToggleFunction()" class="h_two">Purpose of Research</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#research_focus" onclick="toggleFunction()" class="h_two">Research Focus</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#research_focus" onclick="smToggleFunction()" class="h_two">Research Focus</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#catch-up" onclick="toggleFunction()" class="h_two">Catch-up</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#catch-up" onclick="smToggleFunction()" class="h_two">Catch-up</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#research_project_priority" onclick="toggleFunction()" class="h_one">Research Project Priority</a>
+                            <a rel="noopener noreferrer" target="_self" href="#research_project_priority" onclick="smToggleFunction()" class="h_one">Research Project Priority</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#s_tier" onclick="toggleFunction()" class="h_two">S-Tier Projects</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#s_tier" onclick="smToggleFunction()" class="h_two">S-Tier Projects</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#a_tier" onclick="toggleFunction()" class="h_two">A-Tier Projects</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#a_tier" onclick="smToggleFunction()" class="h_two">A-Tier Projects</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#b_tier" onclick="toggleFunction()" class="h_two">B-Tier Projects</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#b_tier" onclick="smToggleFunction()" class="h_two">B-Tier Projects</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#c_tier" onclick="toggleFunction()" class="h_two">C-Tier Projects</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#c_tier" onclick="smToggleFunction()" class="h_two">C-Tier Projects</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#protocore" onclick="toggleFunction()" class="h_one">Protocore</a>
+                            <a rel="noopener noreferrer" target="_self" href="#protocore" onclick="smToggleFunction()" class="h_one">Protocore</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#protocore_spending" onclick="toggleFunction()" class="h_two">Protocore Spending</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#protocore_spending" onclick="smToggleFunction()" class="h_two">Protocore Spending</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#protocore_income" onclick="toggleFunction()" class="h_two">Protocore Income</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#protocore_income" onclick="smToggleFunction()" class="h_two">Protocore Income</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#catch-up_min_max" onclick="toggleFunction()" class="h_two">PR Catch-up Min-Maxing</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#catch-up_min_max" onclick="smToggleFunction()" class="h_two">PR Catch-up Min-Maxing</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#optimizing_protocore" onclick="toggleFunction()" class="h_two">Optimizing Protocore</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#optimizing_protocore" onclick="smToggleFunction()" class="h_two">Optimizing Protocore</a>
                                 </li>
                             </ol>
                         </li>
@@ -1550,7 +1550,7 @@
                                                     
                         <span class="mx-1"></span>
 
-                        <button id="catchupButton" class="btn btn-outline-warning" onclick="catchupToggleFunction()" role="button">
+                        <button id="catchupButton" class="btn btn-outline-warning" onclick="catchupsmToggleFunction()" role="button">
                             <i id="catchupToggle" class="fa fa-angle-down"></i>
                         </button>
                     </h3>

--- a/samvaluation.html
+++ b/samvaluation.html
@@ -135,189 +135,189 @@
                 <div class="toc">
                     <ol>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#Notes" onclick="toggleFunction()" class="toc_h_one">Notes</a>
+                            <a rel="noopener noreferrer" target="_self" href="#Notes" onclick="smToggleFunction()" class="toc_h_one">Notes</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#Augment" onclick="toggleFunction()" class="toc_h_one">Augment Modules</a>
+                            <a rel="noopener noreferrer" target="_self" href="#Augment" onclick="smToggleFunction()" class="toc_h_one">Augment Modules</a>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#Event_Ships" onclick="toggleFunction()" class="toc_h_one">Event Ships</a>
+                            <a rel="noopener noreferrer" target="_self" href="#Event_Ships" onclick="smToggleFunction()" class="toc_h_one">Event Ships</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Ashen_Simulacrum" onclick="toggleFunction()" class="toc_h_two">Ashen Simulacrum</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Ashen_Simulacrum" onclick="smToggleFunction()" class="toc_h_two">Ashen Simulacrum</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Empyreal_Tragicomedy" onclick="toggleFunction()" class="toc_h_two">Empyreal Tragicomedy</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Empyreal_Tragicomedy" onclick="smToggleFunction()" class="toc_h_two">Empyreal Tragicomedy</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Passionate_Polaris" onclick="toggleFunction()" class="toc_h_two">Passionate Polaris</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Passionate_Polaris" onclick="smToggleFunction()" class="toc_h_two">Passionate Polaris</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Swirling_Cherry_Blossoms" onclick="toggleFunction()" class="toc_h_two">Swirling Cherry Blossoms</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Swirling_Cherry_Blossoms" onclick="smToggleFunction()" class="toc_h_two">Swirling Cherry Blossoms</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Northern_Overture" onclick="toggleFunction()" class="toc_h_two">Northern Overture</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Northern_Overture" onclick="smToggleFunction()" class="toc_h_two">Northern Overture</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Microlayer_Medley" onclick="toggleFunction()" class="toc_h_two">Microlayer Medley</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Microlayer_Medley" onclick="smToggleFunction()" class="toc_h_two">Microlayer Medley</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Skybound_Oratorio" onclick="toggleFunction()" class="toc_h_two">Skybound Oratorio</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Skybound_Oratorio" onclick="smToggleFunction()" class="toc_h_two">Skybound Oratorio</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Aurora_Noctis" onclick="toggleFunction()" class="toc_h_two">Aurora Noctis</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Aurora_Noctis" onclick="smToggleFunction()" class="toc_h_two">Aurora Noctis</a>
                                 </li>
                                 
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Dreamwaker's_Butterfly" onclick="toggleFunction()" class="toc_h_two">Dreamwaker's Butterfly</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Dreamwaker's_Butterfly" onclick="smToggleFunction()" class="toc_h_two">Dreamwaker's Butterfly</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Universe_in_Unison" onclick="toggleFunction()" class="toc_h_two">Universe in Unison</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Universe_in_Unison" onclick="smToggleFunction()" class="toc_h_two">Universe in Unison</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Inverted_Orthant" onclick="toggleFunction()" class="toc_h_two">Inverted Orthant</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Inverted_Orthant" onclick="smToggleFunction()" class="toc_h_two">Inverted Orthant</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Khorovod_of_Dawn's_Rime" onclick="toggleFunction()" class="toc_h_two">Khorovod of Dawn's Rime</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Khorovod_of_Dawn's_Rime" onclick="smToggleFunction()" class="toc_h_two">Khorovod of Dawn's Rime</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Daedalian_Hymn" onclick="toggleFunction()" class="toc_h_two">Daedalian Hymn</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Daedalian_Hymn" onclick="smToggleFunction()" class="toc_h_two">Daedalian Hymn</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Mirror_Involution" onclick="toggleFunction()" class="toc_h_two">Mirror Involution</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Mirror_Involution" onclick="smToggleFunction()" class="toc_h_two">Mirror Involution</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Upon_the_Shimmering_Blue" onclick="toggleFunction()" class="toc_h_two">Upon the Shimmering Blue</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Upon_the_Shimmering_Blue" onclick="smToggleFunction()" class="toc_h_two">Upon the Shimmering Blue</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Tower_of_Transcendence" onclick="toggleFunction()" class="toc_h_two">Tower of Transcendence</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Tower_of_Transcendence" onclick="smToggleFunction()" class="toc_h_two">Tower of Transcendence</a>
                                 </li>
 
                                 <!-- INSERT NEW RERUN EVENTS HERE -->
                                 
                                 
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Rondo_at_Rainbow's_End" onclick="toggleFunction()" class="toc_h_two">Rondo at Rainbow's End</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Rondo_at_Rainbow's_End" onclick="smToggleFunction()" class="toc_h_two">Rondo at Rainbow's End</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Pledge_of_the_Radiant_Court" onclick="toggleFunction()" class="toc_h_two">Pledge of the Radiant Court</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Pledge_of_the_Radiant_Court" onclick="smToggleFunction()" class="toc_h_two">Pledge of the Radiant Court</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Angel_of_the_Iris" onclick="toggleFunction()" class="toc_h_two">Angel of the Iris</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Angel_of_the_Iris" onclick="smToggleFunction()" class="toc_h_two">Angel of the Iris</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Aquilifer's_Ballade" onclick="toggleFunction()" class="toc_h_two">Aquilifer's Ballade</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Aquilifer's_Ballade" onclick="smToggleFunction()" class="toc_h_two">Aquilifer's Ballade</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Operation_Convergence" onclick="toggleFunction()" class="toc_h_two">Operation Convergence</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Operation_Convergence" onclick="smToggleFunction()" class="toc_h_two">Operation Convergence</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Violet_Tempest_Blooming_Lycoris" onclick="toggleFunction()" class="toc_h_two">Violet Tempest, Blooming Lycoris</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Violet_Tempest_Blooming_Lycoris" onclick="smToggleFunction()" class="toc_h_two">Violet Tempest, Blooming Lycoris</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Fight_On_Royal_Maids_Part_3" onclick="toggleFunction()" class="toc_h_two">Fight On, Royal Maids! (Part 3) / Halloween Hijinks</a>
-                                </li>
-                                
-                                <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Parallel_Superimposition" onclick="toggleFunction()" class="toc_h_two">Parallel Superimposition</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Fight_On_Royal_Maids_Part_3" onclick="smToggleFunction()" class="toc_h_two">Fight On, Royal Maids! (Part 3) / Halloween Hijinks</a>
                                 </li>
                                 
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Winter_Pathfinder" onclick="toggleFunction()" class="toc_h_two">Winter Pathfinder (Lunar New Year 2023)</a>
-                                </li>
-                                <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Revelations_of_Dust" onclick="toggleFunction()" class="toc_h_two">Revelations of Dust</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Parallel_Superimposition" onclick="smToggleFunction()" class="toc_h_two">Parallel Superimposition</a>
                                 </li>
                                 
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Frostfall" onclick="toggleFunction()" class="toc_h_two">Frostfall</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Winter_Pathfinder" onclick="smToggleFunction()" class="toc_h_two">Winter Pathfinder (Lunar New Year 2023)</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Confluence_of_Nothingness" onclick="toggleFunction()" class="toc_h_two">Confluence of Nothingness</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Revelations_of_Dust" onclick="smToggleFunction()" class="toc_h_two">Revelations of Dust</a>
+                                </li>
+                                
+                                <li>
+                                    <a rel="noopener noreferrer" target="_self" href="#Frostfall" onclick="smToggleFunction()" class="toc_h_two">Frostfall</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Reflections_of_the_Oasis" onclick="toggleFunction()" class="toc_h_two">Reflections of the Oasis</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Confluence_of_Nothingness" onclick="smToggleFunction()" class="toc_h_two">Confluence of Nothingness</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#The_Fool's_Scales" onclick="toggleFunction()" class="toc_h_two">Anthem of Remembrance / The Fool's Scales</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Reflections_of_the_Oasis" onclick="smToggleFunction()" class="toc_h_two">Reflections of the Oasis</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Effulgence_Before_Eclipse" onclick="toggleFunction()" class="toc_h_two">Effulgence Before Eclipse</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#The_Fool's_Scales" onclick="smToggleFunction()" class="toc_h_two">Anthem of Remembrance / The Fool's Scales</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Tempesta_and_the_Fountain_of_Youth" onclick="toggleFunction()" class="toc_h_two">Tempesta and the Fountain of Youth</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Effulgence_Before_Eclipse" onclick="smToggleFunction()" class="toc_h_two">Effulgence Before Eclipse</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Light-Chasing_Sea_of_Stars" onclick="toggleFunction()" class="toc_h_two">Light-Chasing Sea of Stars</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Tempesta_and_the_Fountain_of_Youth" onclick="smToggleFunction()" class="toc_h_two">Tempesta and the Fountain of Youth</a>
+                                </li>
+                                <li>
+                                    <a rel="noopener noreferrer" target="_self" href="#Light-Chasing_Sea_of_Stars" onclick="smToggleFunction()" class="toc_h_two">Light-Chasing Sea of Stars</a>
                                 </li>
 
                                 <!-- INSERT NEW EVENTS HERE -->
                                 <!-- <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Frostfall" onclick="toggleFunction()" class="toc_h_two">Filler</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Frostfall" onclick="smToggleFunction()" class="toc_h_two">Filler</a>
                                 </li> -->
                                 <!-- <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Frostfall" onclick="toggleFunction()" class="toc_h_two">Filler</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Frostfall" onclick="smToggleFunction()" class="toc_h_two">Filler</a>
                                 </li> -->
                                 <!-- <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Frostfall" onclick="toggleFunction()" class="toc_h_two">Filler</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Frostfall" onclick="smToggleFunction()" class="toc_h_two">Filler</a>
                                 </li> -->
                                 <!-- <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Frostfall" onclick="toggleFunction()" class="toc_h_two">Filler</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Frostfall" onclick="smToggleFunction()" class="toc_h_two">Filler</a>
                                 </li> -->
 
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#Shipyard" onclick="toggleFunction()" class="toc_h_one">PR / DR Ships</a>
+                            <a rel="noopener noreferrer" target="_self" href="#Shipyard" onclick="smToggleFunction()" class="toc_h_one">PR / DR Ships</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#PR1" onclick="toggleFunction()" class="toc_h_two">Series 1</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#PR1" onclick="smToggleFunction()" class="toc_h_two">Series 1</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#PR2" onclick="toggleFunction()" class="toc_h_two">Series 2</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#PR2" onclick="smToggleFunction()" class="toc_h_two">Series 2</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#PR3" onclick="toggleFunction()" class="toc_h_two">Series 3</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#PR3" onclick="smToggleFunction()" class="toc_h_two">Series 3</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#PR4" onclick="toggleFunction()" class="toc_h_two">Series 4</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#PR4" onclick="smToggleFunction()" class="toc_h_two">Series 4</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#PR5" onclick="toggleFunction()" class="toc_h_two">Series 5</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#PR5" onclick="smToggleFunction()" class="toc_h_two">Series 5</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#PR6" onclick="toggleFunction()" class="toc_h_two">Series 6</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#PR6" onclick="smToggleFunction()" class="toc_h_two">Series 6</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#META" onclick="toggleFunction()" class="toc_h_one">META Ships</a>
+                            <a rel="noopener noreferrer" target="_self" href="#META" onclick="smToggleFunction()" class="toc_h_one">META Ships</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#META_Showdown" onclick="toggleFunction()" class="toc_h_two">META Showdown</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#META_Showdown" onclick="smToggleFunction()" class="toc_h_two">META Showdown</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Cruise_Pass" onclick="toggleFunction()" class="toc_h_two">Cruise Pass</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Cruise_Pass" onclick="smToggleFunction()" class="toc_h_two">Cruise Pass</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#Collaboration" onclick="toggleFunction()" class="toc_h_one">Collaboration Ships</a>
+                            <a rel="noopener noreferrer" target="_self" href="#Collaboration" onclick="smToggleFunction()" class="toc_h_one">Collaboration Ships</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#DoA" onclick="toggleFunction()" class="toc_h_two">Vacation Lane (Dead or Alive)</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#DoA" onclick="smToggleFunction()" class="toc_h_two">Vacation Lane (Dead or Alive)</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Idolmaster" onclick="toggleFunction()" class="toc_h_two">Azur Anthem (iDOLM@STER)</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Idolmaster" onclick="smToggleFunction()" class="toc_h_two">Azur Anthem (iDOLM@STER)</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#SSSS" onclick="toggleFunction()" class="toc_h_two">World-Spanning Arclight (SSSS Gridman Universe)</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#SSSS" onclick="smToggleFunction()" class="toc_h_two">World-Spanning Arclight (SSSS Gridman Universe)</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Atelier_Ryza" onclick="toggleFunction()" class="toc_h_two">The Alchemist and the Archipelago of Secrets (Atelier Ryza)</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Atelier_Ryza" onclick="smToggleFunction()" class="toc_h_two">The Alchemist and the Archipelago of Secrets (Atelier Ryza)</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#Senran_Kagura" onclick="toggleFunction()" class="toc_h_two">The Ninja Scrolls: Azur Flash (Senran Kagura)</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#Senran_Kagura" onclick="smToggleFunction()" class="toc_h_two">The Ninja Scrolls: Azur Flash (Senran Kagura)</a>
                                 </li>
                             </ol>
                         </li>

--- a/shop_priority.html
+++ b/shop_priority.html
@@ -135,44 +135,44 @@
                 <div class="toc">
                     <ol>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#supply" onclick="toggleFunction()" class="toc_h_one">Supply</a>
+                            <a rel="noopener noreferrer" target="_self" href="#supply" onclick="smToggleFunction()" class="toc_h_one">Supply</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#coin" onclick="toggleFunction()" class="toc_h_two">Shop</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#coin" onclick="smToggleFunction()" class="toc_h_two">Shop</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#merit" onclick="toggleFunction()" class="toc_h_two">Merit Shop</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#merit" onclick="smToggleFunction()" class="toc_h_two">Merit Shop</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#guild" onclick="toggleFunction()" class="toc_h_two">Guild Shop</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#guild" onclick="smToggleFunction()" class="toc_h_two">Guild Shop</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#other" onclick="toggleFunction()" class="toc_h_two">META & Prize Shop</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#other" onclick="smToggleFunction()" class="toc_h_two">META & Prize Shop</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#monthly" onclick="toggleFunction()" class="toc_h_one">Monthly</a>
+                            <a rel="noopener noreferrer" target="_self" href="#monthly" onclick="smToggleFunction()" class="toc_h_one">Monthly</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#core_data" onclick="toggleFunction()" class="toc_h_two">Core Data Shop</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#core_data" onclick="smToggleFunction()" class="toc_h_two">Core Data Shop</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#medal" onclick="toggleFunction()" class="toc_h_two">Medal Shop</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#medal" onclick="smToggleFunction()" class="toc_h_two">Medal Shop</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#protocore" onclick="toggleFunction()" class="toc_h_two">Prototype Shop</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#protocore" onclick="smToggleFunction()" class="toc_h_two">Prototype Shop</a>
                                 </li>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#voucher" onclick="toggleFunction()" class="toc_h_two">Operation Siren Exchange Shop</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#voucher" onclick="smToggleFunction()" class="toc_h_two">Operation Siren Exchange Shop</a>
                                 </li>
                             </ol>
                         </li>
                         <li>
-                            <a rel="noopener noreferrer" target="_self" href="#event" onclick="toggleFunction()" class="toc_h_one">Event</a>
+                            <a rel="noopener noreferrer" target="_self" href="#event" onclick="smToggleFunction()" class="toc_h_one">Event</a>
                             <ol>
                                 <li>
-                                    <a rel="noopener noreferrer" target="_self" href="#major_event" onclick="toggleFunction()" class="toc_h_two">Major Event Shop</a>
+                                    <a rel="noopener noreferrer" target="_self" href="#major_event" onclick="smToggleFunction()" class="toc_h_two">Major Event Shop</a>
                                 </li>
                             </ol>
                         </li>


### PR DESCRIPTION
TOC items currently use the same function as the toggle button which causes them to collapse the sidebar on large screens.  
To fix that, it is replaced with a wrapper function that checks the screen size first.

Also I saw this error while testing on pages without tables (thus no slider) so I fixed the slider snippet at the top as well.
![image](https://github.com/samheart564/ECGC/assets/4302936/e7839eef-1ba6-46fd-b8aa-8f7aa9c74fa4)
